### PR TITLE
Add copyright information into NOTICE file

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,19 +1,4 @@
-﻿﻿--------------------------------------------------------------------------------
-NOTICES FOR jQuery
---------------------------------------------------------------------------------
+﻿﻿cdp-cli
+Copyright 2017, 2018 Sony Network Communications Inc.
 
-- jQuery - ./dev/app/modules/jquery/scripts/jquery.js
-    https://github.com/jquery/jquery
-
-    Released under the MIT Licenses.
-    http://jquery.org/license
-
---------------------------------------------------------------------------------
-NOTICES FOR Jasmine.d.ts
---------------------------------------------------------------------------------
-
- - jasmine.d.ts - ./external/include/jasmine.d.ts
-    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/jasmine/jasmine.d.ts
-
-    Released under the MIT Licenses.
-    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/LICENSE
+This product includes software developed at Sony Network Communications Inc.

--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,26 @@
 Copyright 2017, 2018 Sony Network Communications Inc.
 
 This product includes software developed at Sony Network Communications Inc.
+
+
+This product also includes the following third-party components
+
+--------------------------------------------------------------------------------
+jQuery
+--------------------------------------------------------------------------------
+
+- jQuery - ./dev/app/modules/jquery/scripts/jquery.js
+    https://github.com/jquery/jquery
+
+    Released under the MIT Licenses.
+    http://jquery.org/license
+
+--------------------------------------------------------------------------------
+Jasmine.d.ts
+--------------------------------------------------------------------------------
+
+- jasmine.d.ts - ./external/include/jasmine.d.ts
+    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/jasmine/jasmine.d.ts
+
+    Released under the MIT Licenses.
+    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -104,3 +104,23 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
 See the License for the specific language governing permissions and  
 limitations under the License.
+
+
+## License Notice
+### jQuery
+
+- jQuery - ./dev/app/modules/jquery/scripts/jquery.js
+
+    https://github.com/jquery/jquery
+
+    Released under the MIT Licenses.
+    http://jquery.org/license
+
+### Jasmine.d.ts
+
+- jasmine.d.ts - ./external/include/jasmine.d.ts
+
+    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/jasmine/jasmine.d.ts
+
+    Released under the MIT Licenses.
+    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -104,23 +104,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  
 See the License for the specific language governing permissions and  
 limitations under the License.
-
-
-## License Notice
-### jQuery
-
-- jQuery - ./dev/app/modules/jquery/scripts/jquery.js
-
-    https://github.com/jquery/jquery
-
-    Released under the MIT Licenses.
-    http://jquery.org/license
-
-### Jasmine.d.ts
-
-- jasmine.d.ts - ./external/include/jasmine.d.ts
-
-    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/jasmine/jasmine.d.ts
-
-    Released under the MIT Licenses.
-    https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/LICENSE


### PR DESCRIPTION
The name of 'NOTICE' is corresponding to Apache v 2.0 license 4-d description.
It's better including copyright information in it.